### PR TITLE
add default type-parameter to LedgerBridge

### DIFF
--- a/src/ledger-bridge.ts
+++ b/src/ledger-bridge.ts
@@ -26,7 +26,7 @@ export type LedgerSignTypedDataResponse = Awaited<
   ReturnType<LedgerHwAppEth['signEIP712HashedMessage']>
 >;
 
-export type LedgerBridgeOptions = Record<string, string | number | object>;
+type LedgerBridgeOptions = Record<string, string | number | object>;
 
 export type LedgerBridgeSerializeData = Record<
   string,
@@ -34,7 +34,7 @@ export type LedgerBridgeSerializeData = Record<
 >;
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export interface LedgerBridge<T extends LedgerBridgeOptions> {
+export interface LedgerBridge<T extends LedgerBridgeOptions = LedgerBridgeOptions> {
   isDeviceConnected: boolean;
 
   init(): Promise<void>;

--- a/src/ledger-keyring.ts
+++ b/src/ledger-keyring.ts
@@ -17,7 +17,6 @@ import HDKey from 'hdkey';
 
 import {
   LedgerBridge,
-  LedgerBridgeOptions,
   LedgerBridgeSerializeData,
 } from './ledger-bridge';
 
@@ -35,7 +34,7 @@ enum NetworkApiUrls {
 }
 
 type SignTransactionPayload = Awaited<
-  ReturnType<LedgerBridge<LedgerBridgeOptions>['deviceSignTransaction']>
+  ReturnType<LedgerBridge['deviceSignTransaction']>
 >;
 
 export type AccountDetails = {
@@ -98,9 +97,9 @@ export class LedgerKeyring extends EventEmitter {
 
   implementFullBIP44 = false;
 
-  bridge: LedgerBridge<LedgerBridgeOptions>;
+  bridge: LedgerBridge;
 
-  constructor({ bridge }: { bridge: LedgerBridge<LedgerBridgeOptions> }) {
+  constructor({ bridge }: { bridge: LedgerBridge }) {
     super();
 
     if (!bridge) {


### PR DESCRIPTION
Removes the need to make it explicit and import the type in `ledger-keyring.ts`.